### PR TITLE
Print filename of template that errored

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -307,7 +307,7 @@ object G8 {
       }
     } catch {
       case e: STException =>
-        Left(s"Exiting due to error in the template\n${e.getMessage}")
+        Left(s"Exiting due to error in the template: ${tmpl}\n${e.getMessage}")
       case t: Throwable =>
         Left("Unknown exception: " + t.getMessage)
     }


### PR DESCRIPTION
Fix current unhelpful msg on failure:
```
code$> g8 file://model.g8

Exiting due to error in the template
1:22: premature EOF
```